### PR TITLE
メール認証検証のエッジケース処理を改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 local
+.local/check/cmd/compare_auth/.venv

--- a/arc/header.go
+++ b/arc/header.go
@@ -52,7 +52,7 @@ func (s *Signatures) GetVerifyResultString() string {
 
 	// 最後のインスタンスの結果を取得
 	ah := s.GetInstance(max)
-	if ah == nil {
+	if ah == nil || ah.VerifyResult == nil {
 		return "arc=none"
 	}
 	return fmt.Sprintf("arc=%s (i=%d %s)", ah.VerifyResult.Status(), ah.GetInstanceNumber(), ah.VerifyResult.Message())
@@ -70,7 +70,7 @@ func (s *Signatures) GetVerifyResult() VerifyStatus {
 
 	// 最後のインスタンスの結果を取得
 	ah := s.GetInstance(max)
-	if ah == nil {
+	if ah == nil || ah.VerifyResult == nil {
 		return VerifyStatusNone
 	}
 	return ah.VerifyResult.Status()

--- a/arc/header_test.go
+++ b/arc/header_test.go
@@ -75,6 +75,18 @@ func TestGetARCChainValidationResult(t *testing.T) {
 	}
 }
 
+func TestGetVerifyResultHandlesUnverifiedSignature(t *testing.T) {
+	var sigs Signatures
+	sigs.GetInstance(1)
+
+	if got := sigs.GetVerifyResult(); got != VerifyStatusNone {
+		t.Fatalf("expected none for unverified ARC signature, got %s", got)
+	}
+	if got := sigs.GetVerifyResultString(); got != "arc=none" {
+		t.Fatalf("expected arc=none for unverified ARC signature, got %s", got)
+	}
+}
+
 func TestParseARCHeaders(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/dkim/dkim.go
+++ b/dkim/dkim.go
@@ -96,14 +96,30 @@ func (ds *Signature) GetCanonicalizationAndAlgorithm() *CanonicalizationAndAlgor
 }
 
 func (ds *Signature) String() string {
+	var optional []string
+	if ds.Identity != "" {
+		optional = append(optional, fmt.Sprintf("        i=%s;\r\n", ds.Identity))
+	}
+	if ds.Limit > 0 {
+		optional = append(optional, fmt.Sprintf("        l=%d;\r\n", ds.Limit))
+	}
+	if ds.QueryType != "" {
+		optional = append(optional, fmt.Sprintf("        q=%s;\r\n", ds.QueryType))
+	}
+	if ds.SignatureExpiration > 0 {
+		optional = append(optional, fmt.Sprintf("        x=%d;\r\n", ds.SignatureExpiration))
+	}
+
 	return fmt.Sprintf("a=%s; bh=%s;\r\n"+
 		"        c=%s; d=%s;\r\n"+
 		"        h=%s;\r\n"+
+		"%s"+
 		"        s=%s; t=%d; v=%d;\r\n"+
 		"        b=%s",
 		ds.Algorithm, ds.BodyHash,
 		ds.Canonicalization, ds.Domain,
 		ds.Headers,
+		strings.Join(optional, ""),
 		ds.Selector, ds.Timestamp, ds.Version,
 		header.WrapSignatureWithBreaks(ds.Signature),
 	)
@@ -408,6 +424,16 @@ func (d *Signature) VerifyWithResolver(headers []string, bodyHash string, domain
 		return
 	}
 
+	if err := d.validateDomainKeyPolicy(domainKey); err != nil {
+		d.VerifyResult = &VerifyResult{
+			status:    VerifyStatusPermErr,
+			err:       err,
+			msg:       err.Error() + testFlagMsg,
+			domainKey: domainKey,
+		}
+		return
+	}
+
 	// expireを検証 (RFC 6376要件)
 	// TimestampとSignatureExpirationがセットされてない場合は検証しない
 	if d.SignatureExpiration != 0 {
@@ -542,6 +568,61 @@ func (d *Signature) VerifyWithResolver(headers []string, bodyHash string, domain
 		msg:       "good signature" + testFlagMsg,
 		domainKey: domainKey,
 	}
+}
+
+func (d *Signature) validateDomainKeyPolicy(domainKey *domainkey.DomainKey) error {
+	if domainKey == nil {
+		return nil
+	}
+
+	if len(domainKey.HashAlgo) > 0 {
+		want := domainkey.HashAlgoSHA256
+		legacyWant := domainkey.HashAlgo(d.Algorithm)
+		switch d.Algorithm {
+		case SignatureAlgorithmRSA_SHA1:
+			want = domainkey.HashAlgoSHA1
+		case SignatureAlgorithmRSA_SHA256, SignatureAlgorithmED25519_SHA256:
+			want = domainkey.HashAlgoSHA256
+		}
+		allowed := false
+		for _, algo := range domainKey.HashAlgo {
+			if algo == want || algo == legacyWant {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("signature hash algorithm is not allowed by domain key")
+		}
+	}
+
+	if domainKey.KeyType != "" {
+		switch d.Algorithm {
+		case SignatureAlgorithmRSA_SHA1, SignatureAlgorithmRSA_SHA256:
+			if domainKey.KeyType != domainkey.KeyTypeRSA {
+				return fmt.Errorf("signature key type is not allowed by domain key")
+			}
+		case SignatureAlgorithmED25519_SHA256:
+			if domainKey.KeyType != domainkey.KeyTypeED25519 {
+				return fmt.Errorf("signature key type is not allowed by domain key")
+			}
+		}
+	}
+
+	for _, flag := range domainKey.SelectorFlags {
+		if flag != domainkey.SelectorFlagsStrictDomain {
+			continue
+		}
+		identityDomain := d.Domain
+		if atIndex := strings.LastIndex(d.Identity, "@"); atIndex != -1 {
+			identityDomain = d.Identity[atIndex+1:]
+		}
+		if !strings.EqualFold(identityDomain, d.Domain) {
+			return fmt.Errorf("identity domain is not allowed by strict domain key")
+		}
+	}
+
+	return nil
 }
 
 func hashAlgo(algo SignatureAlgorithm) crypto.Hash {

--- a/dkim/dkim.go
+++ b/dkim/dkim.go
@@ -577,7 +577,6 @@ func (d *Signature) validateDomainKeyPolicy(domainKey *domainkey.DomainKey) erro
 
 	if len(domainKey.HashAlgo) > 0 {
 		want := domainkey.HashAlgoSHA256
-		legacyWant := domainkey.HashAlgo(d.Algorithm)
 		switch d.Algorithm {
 		case SignatureAlgorithmRSA_SHA1:
 			want = domainkey.HashAlgoSHA1
@@ -586,7 +585,7 @@ func (d *Signature) validateDomainKeyPolicy(domainKey *domainkey.DomainKey) erro
 		}
 		allowed := false
 		for _, algo := range domainKey.HashAlgo {
-			if algo == want || algo == legacyWant {
+			if algo == want {
 				allowed = true
 				break
 			}
@@ -596,16 +595,18 @@ func (d *Signature) validateDomainKeyPolicy(domainKey *domainkey.DomainKey) erro
 		}
 	}
 
-	if domainKey.KeyType != "" {
-		switch d.Algorithm {
-		case SignatureAlgorithmRSA_SHA1, SignatureAlgorithmRSA_SHA256:
-			if domainKey.KeyType != domainkey.KeyTypeRSA {
-				return fmt.Errorf("signature key type is not allowed by domain key")
-			}
-		case SignatureAlgorithmED25519_SHA256:
-			if domainKey.KeyType != domainkey.KeyTypeED25519 {
-				return fmt.Errorf("signature key type is not allowed by domain key")
-			}
+	keyType := domainKey.KeyType
+	if keyType == "" {
+		keyType = domainkey.KeyTypeRSA
+	}
+	switch d.Algorithm {
+	case SignatureAlgorithmRSA_SHA1, SignatureAlgorithmRSA_SHA256:
+		if keyType != domainkey.KeyTypeRSA {
+			return fmt.Errorf("signature key type is not allowed by domain key")
+		}
+	case SignatureAlgorithmED25519_SHA256:
+		if keyType != domainkey.KeyTypeED25519 {
+			return fmt.Errorf("signature key type is not allowed by domain key")
 		}
 	}
 

--- a/dkim/dkim_test.go
+++ b/dkim/dkim_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"strings"
 	"testing"
 
 	"github.com/masa23/mmauth/domainkey"
@@ -318,6 +319,96 @@ func TestParseDKIMSignature(t *testing.T) {
 			}
 			if actual.canonnAndAlgo.HashAlgo != tc.expected.canonnAndAlgo.HashAlgo {
 				t.Errorf("want %v, but got %v", tc.expected.canonnAndAlgo.HashAlgo, actual.canonnAndAlgo.HashAlgo)
+			}
+		})
+	}
+}
+
+func TestSignatureStringIncludesOptionalTags(t *testing.T) {
+	sig := &Signature{
+		Algorithm:           SignatureAlgorithmRSA_SHA256,
+		BodyHash:            "bodyhash",
+		Canonicalization:    "relaxed/relaxed",
+		Domain:              "example.com",
+		Headers:             "from:to",
+		Identity:            "user@example.com",
+		Limit:               123,
+		QueryType:           "dns/txt",
+		Selector:            "selector",
+		Timestamp:           1700000000,
+		Version:             1,
+		SignatureExpiration: 1700003600,
+		Signature:           "signature",
+	}
+
+	got := sig.String()
+	for _, want := range []string{
+		"i=user@example.com;",
+		"l=123;",
+		"q=dns/txt;",
+		"x=1700003600;",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected signature string to contain %q, got %s", want, got)
+		}
+	}
+}
+
+func TestVerifyRejectsDomainKeyPolicyMismatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		signature *Signature
+		key       domainkey.DomainKey
+	}{
+		{
+			name: "hash algorithm not allowed",
+			signature: &Signature{
+				Algorithm: SignatureAlgorithmRSA_SHA256,
+				Domain:    "example.com",
+				Identity:  "user@example.com",
+				Version:   1,
+				raw:       "DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=selector; h=from; bh=; b=",
+			},
+			key: domainkey.DomainKey{
+				HashAlgo: []domainkey.HashAlgo{domainkey.HashAlgoSHA1},
+			},
+		},
+		{
+			name: "key type not allowed",
+			signature: &Signature{
+				Algorithm: SignatureAlgorithmED25519_SHA256,
+				Domain:    "example.com",
+				Identity:  "user@example.com",
+				Version:   1,
+				raw:       "DKIM-Signature: v=1; a=ed25519-sha256; d=example.com; s=selector; h=from; bh=; b=",
+			},
+			key: domainkey.DomainKey{
+				KeyType: domainkey.KeyTypeRSA,
+			},
+		},
+		{
+			name: "strict identity domain",
+			signature: &Signature{
+				Algorithm: SignatureAlgorithmRSA_SHA256,
+				Domain:    "example.com",
+				Identity:  "user@sub.example.com",
+				Version:   1,
+				raw:       "DKIM-Signature: v=1; a=rsa-sha256; d=example.com; i=user@sub.example.com; s=selector; h=from; bh=; b=",
+			},
+			key: domainkey.DomainKey{
+				SelectorFlags: []domainkey.SelectorFlags{domainkey.SelectorFlagsStrictDomain},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.signature.Verify(nil, "", &tt.key)
+			if tt.signature.VerifyResult == nil {
+				t.Fatal("expected verify result")
+			}
+			if tt.signature.VerifyResult.Status() != VerifyStatusPermErr {
+				t.Fatalf("expected permerror, got %s", tt.signature.VerifyResult.Status())
 			}
 		})
 	}

--- a/dkim/dkim_test.go
+++ b/dkim/dkim_test.go
@@ -359,6 +359,7 @@ func TestVerifyRejectsDomainKeyPolicyMismatch(t *testing.T) {
 		name      string
 		signature *Signature
 		key       domainkey.DomainKey
+		wantErr   string
 	}{
 		{
 			name: "hash algorithm not allowed",
@@ -372,6 +373,7 @@ func TestVerifyRejectsDomainKeyPolicyMismatch(t *testing.T) {
 			key: domainkey.DomainKey{
 				HashAlgo: []domainkey.HashAlgo{domainkey.HashAlgoSHA1},
 			},
+			wantErr: "signature hash algorithm is not allowed by domain key",
 		},
 		{
 			name: "key type not allowed",
@@ -385,6 +387,19 @@ func TestVerifyRejectsDomainKeyPolicyMismatch(t *testing.T) {
 			key: domainkey.DomainKey{
 				KeyType: domainkey.KeyTypeRSA,
 			},
+			wantErr: "signature key type is not allowed by domain key",
+		},
+		{
+			name: "empty key type defaults to rsa",
+			signature: &Signature{
+				Algorithm: SignatureAlgorithmED25519_SHA256,
+				Domain:    "example.com",
+				Identity:  "user@example.com",
+				Version:   1,
+				raw:       "DKIM-Signature: v=1; a=ed25519-sha256; d=example.com; s=selector; h=from; bh=; b=",
+			},
+			key:     domainkey.DomainKey{},
+			wantErr: "signature key type is not allowed by domain key",
 		},
 		{
 			name: "strict identity domain",
@@ -398,6 +413,7 @@ func TestVerifyRejectsDomainKeyPolicyMismatch(t *testing.T) {
 			key: domainkey.DomainKey{
 				SelectorFlags: []domainkey.SelectorFlags{domainkey.SelectorFlagsStrictDomain},
 			},
+			wantErr: "identity domain is not allowed by strict domain key",
 		},
 	}
 
@@ -409,6 +425,12 @@ func TestVerifyRejectsDomainKeyPolicyMismatch(t *testing.T) {
 			}
 			if tt.signature.VerifyResult.Status() != VerifyStatusPermErr {
 				t.Fatalf("expected permerror, got %s", tt.signature.VerifyResult.Status())
+			}
+			if tt.signature.VerifyResult.Error() == nil {
+				t.Fatal("expected verify error")
+			}
+			if tt.signature.VerifyResult.Error().Error() != tt.wantErr {
+				t.Fatalf("expected error %q, got %q", tt.wantErr, tt.signature.VerifyResult.Error().Error())
 			}
 		})
 	}
@@ -528,7 +550,7 @@ func TestVerify(t *testing.T) {
 				"Message-Id: <20240203233642.F020.87DC113@example.com>\r\n",
 			},
 			domainKey: domainkey.DomainKey{
-				HashAlgo:  []domainkey.HashAlgo{"rsa-sha256"},
+				HashAlgo:  []domainkey.HashAlgo{domainkey.HashAlgoSHA256},
 				KeyType:   "rsa",
 				PublicKey: publicKeyB64,
 			},
@@ -567,7 +589,7 @@ func TestVerify(t *testing.T) {
 				"Message-Id: <20240203233642.F020.87DC113@example.com>\r\n",
 			},
 			domainKey: domainkey.DomainKey{
-				HashAlgo:  []domainkey.HashAlgo{"rsa-sha256"},
+				HashAlgo:  []domainkey.HashAlgo{domainkey.HashAlgoSHA256},
 				KeyType:   "rsa",
 				PublicKey: publicKeyB64,
 			},
@@ -606,7 +628,7 @@ func TestVerify(t *testing.T) {
 				"Message-Id: <20240203233642.F020.87DC113@example.com>\r\n",
 			},
 			domainKey: domainkey.DomainKey{
-				HashAlgo:  []domainkey.HashAlgo{"rsa-sha256"},
+				HashAlgo:  []domainkey.HashAlgo{domainkey.HashAlgoSHA256},
 				KeyType:   "rsa",
 				PublicKey: publicKeyB64,
 			},

--- a/dkim/header.go
+++ b/dkim/header.go
@@ -18,6 +18,9 @@ func (d *Signatures) GetResult() VerifyStatus {
 		return VerifyStatusNone
 	}
 	for _, sig := range *d {
+		if sig == nil || sig.VerifyResult == nil {
+			return VerifyStatusNone
+		}
 		if sig.VerifyResult.Status() != VerifyStatusPass {
 			return sig.VerifyResult.Status()
 		}

--- a/dkim/header_test.go
+++ b/dkim/header_test.go
@@ -50,6 +50,13 @@ func TestGetResult(t *testing.T) {
 			signatures: nil,
 			expected:   VerifyStatusNone,
 		},
+		{
+			name: "Unverified Signature",
+			signatures: Signatures{
+				&Signature{},
+			},
+			expected: VerifyStatusNone,
+		},
 	}
 
 	for _, c := range cases {

--- a/dmarc/dmarc.go
+++ b/dmarc/dmarc.go
@@ -19,6 +19,7 @@ var DefaultResolver TXTLookupFunc = net.LookupTXT
 var (
 	ErrNoRecordFound   = errors.New("no record found")
 	ErrDNSLookupFailed = errors.New("dns lookup failed")
+	ErrMultipleRecords = errors.New("multiple DMARC records found")
 )
 
 type AlignmentMode string
@@ -234,6 +235,15 @@ func LookupRecordWithSubdomainFallback(domain string) (*Record, error) {
 	}
 }
 
+func isDMARCRecord(raw string) bool {
+	firstTag, _, _ := strings.Cut(strings.TrimSpace(raw), ";")
+	key, value, ok := strings.Cut(firstTag, "=")
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(key), "v") && strings.TrimSpace(value) == "DMARC1"
+}
+
 func LookupRecord(domain string) (*Record, error) {
 	query := fmt.Sprintf("_dmarc.%s", domain)
 	res, err := DefaultResolver(query)
@@ -244,7 +254,16 @@ func LookupRecord(domain string) (*Record, error) {
 	} else if err != nil {
 		return nil, fmt.Errorf("dns lookup failed: %w", err)
 	}
+	var dmarcRecords []string
 	for _, v := range res {
+		if isDMARCRecord(v) {
+			dmarcRecords = append(dmarcRecords, v)
+		}
+	}
+	if len(dmarcRecords) > 1 {
+		return nil, ErrMultipleRecords
+	}
+	for _, v := range dmarcRecords {
 		d, err := ParseRecord(v)
 		if err != nil {
 			return nil, err

--- a/dmarc/dmarc_test.go
+++ b/dmarc/dmarc_test.go
@@ -171,6 +171,32 @@ func TestLookupRecord(t *testing.T) {
 			},
 			wantErr: ErrNoRecordFound,
 		},
+		{
+			domain: "example.jp",
+			want: &Record{
+				Version: "DMARC1",
+				Policy:  "reject",
+				raw:     "v=DMARC1; p=reject;",
+			},
+			resolver: func(name string) ([]string, error) {
+				if name == "_dmarc.example.jp" {
+					return []string{"not a dmarc record", "v=DMARC1; p=reject;"}, nil
+				}
+				return nil, &net.DNSError{IsNotFound: true}
+			},
+			wantErr: nil,
+		},
+		{
+			domain: "example.jp",
+			want:   nil,
+			resolver: func(name string) ([]string, error) {
+				if name == "_dmarc.example.jp" {
+					return []string{"v=DMARC1; p=none;", "v=DMARC1; p=reject;"}, nil
+				}
+				return nil, &net.DNSError{IsNotFound: true}
+			},
+			wantErr: ErrMultipleRecords,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/header_test.go
+++ b/header_test.go
@@ -83,6 +83,16 @@ func Test_readHeader(t *testing.T) {
 	}
 }
 
+func TestMMAuthCloseReturnsParseError(t *testing.T) {
+	m := NewMMAuth()
+	if _, err := m.Write([]byte("header:value")); err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+	if err := m.Close(); err == nil || !strings.Contains(err.Error(), "failed to read header") {
+		t.Fatalf("expected parse error from Close, got %v", err)
+	}
+}
+
 func Test_hashAlgo(t *testing.T) {
 	testCases := []struct {
 		name   string

--- a/mmauth.go
+++ b/mmauth.go
@@ -273,7 +273,16 @@ func (m *MMAuth) Close() error {
 	err := m.pw.Close()
 	m.pclose = true
 	<-m.done
-	return err
+	if err != nil && m.err != nil {
+		return fmt.Errorf("failed to close pipe: %v; processing error: %w", err, m.err)
+	}
+	if err != nil {
+		return err
+	}
+	if m.err != nil {
+		return m.err
+	}
+	return nil
 }
 
 // 付与されているDKIM・ARCの署名検証を行う


### PR DESCRIPTION
## 概要

メール認証検証まわりのエッジケース処理を改善しました。

## 変更内容

- DKIM DomainKey のポリシー検証を追加
  - ハッシュアルゴリズム
  - 鍵種別
  - strict domain フラグ
- DMARC レコードが複数存在する場合にエラーを返すよう修正
- ARC/DKIM の検証結果が未設定の場合に panic しないよう修正
- `MMAuth.Close()` で処理中に発生したエラーも返すよう修正
- `DKIM-Signature` の文字列表現に任意タグを含めるよう修正

## テスト

- 各変更に対応するユニットテストを追加・更新